### PR TITLE
Basic setup.py file for #8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 __pycache__
 *.pyc
 /.idea
+build/
+dist/
+*.egg-info/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.md
+include setup.py
+recursive-include ugly *.py

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+
+classifiers = ['Development Status :: 3 - Alpha',
+               'Operating System :: POSIX :: Linux',
+               'License :: OSI Approved :: MIT License',
+               'Intended Audience :: Developers',
+               'Programming Language :: Python :: 2.6',
+               'Programming Language :: Python :: 2.7',
+               'Programming Language :: Python :: 3',
+               'Topic :: Software Development',
+               'Topic :: System :: Hardware']
+
+setup(
+    name            = 'ugly',
+    version         = '0.0.0',
+    author          = 'A. Buxton',
+    author_email    = '',
+    description     = 'Unified Graphics Library Yarrr',
+    long_description= open('README.md').read(),
+    license         = 'GPL-3.0',
+    keywords        = 'Raspberry Pi',
+    url             = '',
+    classifiers     = classifiers,
+    py_modules      = [],
+    packages        = ['ugly'],
+    include_package_data = True,
+    install_requires= []
+)


### PR DESCRIPTION
Tentative first PR! Just a basic setup.py to get the ball rolling for #8.

IMO the library parts of this repository should live under "library" so that the examples can live under "examples" and documentation under "documentation". This would also let you maintain (via pandoc) a .rst version of the README in the library folder which would format correctly on pypi.python.org.